### PR TITLE
Add Indonesian stop words

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Language | Authors | Notes
  [Hebrew](yaml/stopwords_he.yml) | Elad Segev |
  [Japanese](yaml/stopwords_ja.yml) | Kohei Watanabe
  Chinese [Traditional](yaml/stopwords_zh_traditional.yml) / [Simplified](yaml/stopwords_zh_simplified.yml) | Chung-hong Chan, Yuan Zhou
-
+ [Indonasian](yaml/stopwords_id.yml) | Hiroko Kinoshita
+ 
 We will continue to improve the lists and add more languages to enable cross-lingual quantitative text analysis. If you are interested in contributing to this project, please contact us.
 
 Marimo stopwords lists are available via the [stopwords](https://cran.r-project.org/web/packages/stopwords/index.html) package in R.

--- a/tests.R
+++ b/tests.R
@@ -3,4 +3,5 @@ require(testthat)
 for (f in list.files("yaml", full.names = TRUE)) {
     cat("Read ", f, "\n")
     expect_silent(yaml::read_yaml(f))
+    expect_equal(sum(duplicated(unlist(lis))), 0)
 }

--- a/tests.R
+++ b/tests.R
@@ -2,6 +2,8 @@ require(testthat)
 
 for (f in list.files("yaml", full.names = TRUE)) {
     cat("Read ", f, "\n")
-    expect_silent(yaml::read_yaml(f))
-    expect_equal(sum(duplicated(unlist(lis))), 0)
+    expect_silent({ 
+        lis <- yaml::read_yaml(f)
+    })
+    cat(sum(duplicated(unlist(lis))), "duplicates\n")
 }

--- a/tests.R
+++ b/tests.R
@@ -5,5 +5,6 @@ for (f in list.files("yaml", full.names = TRUE)) {
     expect_silent({ 
         lis <- yaml::read_yaml(f)
     })
+    cat(sum(stringi::stri_count_regex(unlist(lis), "\\p{Z}")), "non-word, ")
     cat(sum(duplicated(unlist(lis))), "duplicates\n")
 }

--- a/tests.R
+++ b/tests.R
@@ -1,11 +1,14 @@
-require(testthat)
+library(testthat)
+library(stringi)
 
 for (f in list.files("yaml", full.names = TRUE)) {
     cat("Read ", f, "\n")
     expect_silent({ 
         lis <- yaml::read_yaml(f)
     })
-    cat(sum(stringi::stri_count_regex(unlist(lis), " ")), "n-grams, ")
-    cat(sum(stringi::stri_count_regex(unlist(lis), "\\p{Z}")), "non-word, ")
-    cat(sum(duplicated(unlist(lis))), "duplicates\n")
+    v <- unlist(lis)
+    cat(sum(stri_trans_tolower(v) != v), "upper-case, ")
+    cat(sum(stri_count_regex(v, " ")), "n-grams, ")
+    cat(sum(stri_count_regex(v, "\\p{Z}")), "non-word, ")
+    cat(sum(duplicated(v)), "duplicates\n")
 }

--- a/tests.R
+++ b/tests.R
@@ -5,6 +5,7 @@ for (f in list.files("yaml", full.names = TRUE)) {
     expect_silent({ 
         lis <- yaml::read_yaml(f)
     })
+    cat(sum(stringi::stri_count_regex(unlist(lis), " ")), "n-grams, ")
     cat(sum(stringi::stri_count_regex(unlist(lis), "\\p{Z}")), "non-word, ")
     cat(sum(duplicated(unlist(lis))), "duplicates\n")
 }

--- a/yaml/stopwords_id.yml
+++ b/yaml/stopwords_id.yml
@@ -1,41 +1,39 @@
 # Created by Hirokoi Kinoshita for the marimo stopwords: https://github.com/koheiw/marimo
-
-stopwords:
-    pronoun: 
-        basic: 
-            - [saya, aku, gue, daku, diri, diri sendiri, sendiri, saya sendiri, kita, kami, milik kita, milik kami, punya kami, anda, kamu, kau, kalian, engkau, saudara, milikmu, milik anda, milik kamu, dirimu sendiri, dia, ia, beliau, himself, kepunyaannya, punyanya, itu, ini, mereka, milik mereka, punya mereka, mereka empunya, yang ini, bahwa, yang, sehingga, agar, kalau, supaya, maka, bahwasanya, agar supaya, di waktu mana]
-        possesive: 
-            - [saya,  milikku, milik saya, kami, kita, Anda, kamu, saudara, kau, engkau, dia, ia, mereka, para]
-        interogative: 
-            # added "whose"
-            - [apa, yang, mana, alangkah, mana saja, siapa, siapa saja, siapapun, kapan, ketika, jika, kapan, waktu, kalau, sewaktu, bila, apabila, bilamana, dimana, ke mana, dari mana, dimana, padahal, mengapa, kenapa, kok, apa sebab, sebab, bagaimana, berapa, betapa, bagaimana caranya, cara, metode, macam]
-        contraction: 
-            - [saya, kamu adalah, dia adalah, ia adalah, ini, itulah, sekarang, kita, kami, mereka, saya sudah, saya punya, kami punya, anda punya, kita punya, mereka punya, saya akan, saya ingin, kamu akan, anda akan, anda ingin, dia akan, dia ingin, ia akan, ia ingin, kita akan, kita ingin, kami akan, kami ingin, mereka akan, mereka ingin, saya akan, aku akan, kamu akan, anda akan, ia akan, dia akan, kami akan, kita akan, mereka akan, kh, KH, sudah]
-    verb: 
-        basic: 
-            - [adalah, ialah, dulu, dulu, menjadi, ada, berada, telah, memiliki, mempunyai, ada, mendapat, punya, memiliki, mempunyai, melakukan, berbuat, membuat, buat, dilakukan, perbuatan,merupakan]
-        modal: 
-            - [akan, sebaiknya, harus, seharusnya, sebaiknya, semestinya, patut, bisa, dapat, mungkin, mau, siap, barangkali, seharusnya, patut, lebih baik, akan, bekal, biasa, mungkin]
-        contraction: 
-            - [tidak, tidak, tidak, tidak, bukan, tidak punya, tidak punya, tidak punya, tidak, jangan, tak, tidak akan, tidak akan, jangan, tidak bisa, tdk dapat, tdk bisa, tidak harus, ayo, itu adalah, siapa yang, apa yang, disini adalah, adah, adalah, kapan, dimana, kenapa, bagaimana,hal]
-        reporting: 
-            # added
-            - [mengatakan, kata, berkata, mengucapkan, berucap, ujar, berpendapat, bilang, membilangkan, mengomong, memprikan, mengira, kata, tersebut, yg disebut di atas, yang disebut di atas, menceritakan, mengatakan, menyuruh, memberitahukan, bercerita, mengetahui, mengenali, mengenal, menunjukkan, menandakan, jelaskan, mengadukan, deberitahu, melaporkan, melapor, mengabarkan, memberitahu, mewartakan, lapor, merencana, unjuk bertahu, laporan, warta, renana, repot, dilaporkan]
-    article: 
-        - [sebuah, seorang, sebatang, itu, sang]
-    conjunction: 
-        - [dan, serta, dengan, en, tambah, tapi, tetapi, melainkan, akan tetapi, meskipun begitu, rupanya, jika, apakah, kalau, bila, apabila, jikalau, atau, karena, sebab, lantaran, begitu, amat, jadi, demikian, juga, sekali, jua, sementara, sedangkan, selagi, sambil, waktu, meskipun, sembari, walaupun, meski, seraya, saat, maupun, namun]
-    adverb: 
-        # added "many"
-        - [sebagai, karena, ketika, betapa, seperti, ajak, sampai, sehingga, hingga, sekali, pernah, sini, di sini, ke sini, ke mari, begini, ini, sana, di sana, ke sana, situ, di situ, ke situ, sekian, sang, semua, segenap, segela, sekalian, apa saja, apa pun, sesuatu, siapa saja, barang, apa-apa, kedua, keduanya, berdua, kedua-duanya, setiap, tiap, tiap-tiap, masing-masing, beberapa, sedikit, tidak banyak, tdk banyak, banyak, lebih, lagi, tambah, menang, paling, sangat, amat, terlebih, lain, satu lagi, beberapa, salah, salah satu, suatu, stengah, hebat, seperti, seperti itu, sedemikian, begitu, serupa itu, sekali, tidak, tidaklah, tidak, hanya, saja, baru, cuma, semata-mata, melulu, doang, doangan, kemudian, sesudah itu, maka, lalu, setelah itu, waktu itu, pun, terus, teralu, juga, pun, sangat, terlampau, pula, kelewat, sekali, benar-benar, jua, sangat, amat, begitu, banget, benar, seluruh]
-    preposition: 
-        - [dari, di, oleh, dengan, menurut, untuk, bagi, selama, dengan, bersama, pada, tentang, megenai, soal, terhadap, di sekitar, melawan, terhadap menentang, antara, di antara, ke, menjadi, ke dalam, melalui, lewat, melewati, sampai, selama, semasa, sementara,  sebelum, daripada, sebelum, di hadapan, di depan, di muka, stelah, sesudah, demi, sehabis, atas,  di atas, bawah, di bawah, ke, dari, naik, ke atas, menaikkan, turun, ke bawah, di bawah, turun, menurunkan, menjatuhkan, meletakkan, di, dalam, pada, di dalam, dengan, secara, untuk, lagi, di luar, ke luar, luar, pingsan, hanyut, lebih, di atas, ke atas, lagi, sisa, tersisa, dibawah, di bawah, bawah, lagi, kembali, sekali lagi, pula, lebih lanjut, lebih jauh, selanjutnya,  dari, daripada, kecuali, kepada]
-    adjectives: 
-        - [sendiri, kepunyaan sendiri, sama, serupa, sama saja] 
-    time: 
+pronoun: 
+    basic: 
+        - [saya, aku, gue, daku, diri, diri sendiri, sendiri, saya sendiri, kita, kami, milik kita, milik kami, punya kami, anda, kamu, kau, kalian, engkau, saudara, milikmu, milik anda, milik kamu, dirimu sendiri, dia, ia, beliau, himself, kepunyaannya, punyanya, itu, ini, mereka, milik mereka, punya mereka, mereka empunya, yang ini, bahwa, yang, sehingga, agar, kalau, supaya, maka, bahwasanya, agar supaya, di waktu mana]
+    possesive: 
+        - [saya,  milikku, milik saya, kami, kita, Anda, kamu, saudara, kau, engkau, dia, ia, mereka, para]
+    interogative: 
+        # added "whose"
+        - [apa, yang, mana, alangkah, mana saja, siapa, siapa saja, siapapun, kapan, ketika, jika, kapan, waktu, kalau, sewaktu, bila, apabila, bilamana, dimana, ke mana, dari mana, dimana, padahal, mengapa, kenapa, kok, apa sebab, sebab, bagaimana, berapa, betapa, bagaimana caranya, cara, metode, macam]
+    contraction: 
+        - [saya, kamu adalah, dia adalah, ia adalah, ini, itulah, sekarang, kita, kami, mereka, saya sudah, saya punya, kami punya, anda punya, kita punya, mereka punya, saya akan, saya ingin, kamu akan, anda akan, anda ingin, dia akan, dia ingin, ia akan, ia ingin, kita akan, kita ingin, kami akan, kami ingin, mereka akan, mereka ingin, saya akan, aku akan, kamu akan, anda akan, ia akan, dia akan, kami akan, kita akan, mereka akan, kh, KH, sudah]
+verb: 
+    basic: 
+        - [adalah, ialah, dulu, dulu, menjadi, ada, berada, telah, memiliki, mempunyai, ada, mendapat, punya, memiliki, mempunyai, melakukan, berbuat, membuat, buat, dilakukan, perbuatan,merupakan]
+    modal: 
+        - [akan, sebaiknya, harus, seharusnya, sebaiknya, semestinya, patut, bisa, dapat, mungkin, mau, siap, barangkali, seharusnya, patut, lebih baik, akan, bekal, biasa, mungkin]
+    contraction: 
+        - [tidak, tidak, tidak, tidak, bukan, tidak punya, tidak punya, tidak punya, tidak, jangan, tak, tidak akan, tidak akan, jangan, tidak bisa, tdk dapat, tdk bisa, tidak harus, ayo, itu adalah, siapa yang, apa yang, disini adalah, adah, adalah, kapan, dimana, kenapa, bagaimana,hal]
+    reporting: 
         # added
-        - [menit, detik, jam, pukul, saat, waktu, bulan, tahun,  abad, kurun, am, pm, hari]
-        - [januari, februari, maret, april, april, mei, juni, juli, agustus, september, oktober, november, desember, jan, feb, mar, apr, mei, jun, jul, aug, sep, sept, okt, nov, des]
-    number:
-        - [satu, dua, tiga, empat, lima, enam, tujuj, delapan, sembilan, sepuluh]
+        - [mengatakan, kata, berkata, mengucapkan, berucap, ujar, berpendapat, bilang, membilangkan, mengomong, memprikan, mengira, kata, tersebut, yg disebut di atas, yang disebut di atas, menceritakan, mengatakan, menyuruh, memberitahukan, bercerita, mengetahui, mengenali, mengenal, menunjukkan, menandakan, jelaskan, mengadukan, deberitahu, melaporkan, melapor, mengabarkan, memberitahu, mewartakan, lapor, merencana, unjuk bertahu, laporan, warta, renana, repot, dilaporkan]
+article: 
+    - [sebuah, seorang, sebatang, itu, sang]
+conjunction: 
+    - [dan, serta, dengan, en, tambah, tapi, tetapi, melainkan, akan tetapi, meskipun begitu, rupanya, jika, apakah, kalau, bila, apabila, jikalau, atau, karena, sebab, lantaran, begitu, amat, jadi, demikian, juga, sekali, jua, sementara, sedangkan, selagi, sambil, waktu, meskipun, sembari, walaupun, meski, seraya, saat, maupun, namun]
+adverb: 
+    # added "many"
+    - [sebagai, karena, ketika, betapa, seperti, ajak, sampai, sehingga, hingga, sekali, pernah, sini, di sini, ke sini, ke mari, begini, ini, sana, di sana, ke sana, situ, di situ, ke situ, sekian, sang, semua, segenap, segela, sekalian, apa saja, apa pun, sesuatu, siapa saja, barang, apa-apa, kedua, keduanya, berdua, kedua-duanya, setiap, tiap, tiap-tiap, masing-masing, beberapa, sedikit, tidak banyak, tdk banyak, banyak, lebih, lagi, tambah, menang, paling, sangat, amat, terlebih, lain, satu lagi, beberapa, salah, salah satu, suatu, stengah, hebat, seperti, seperti itu, sedemikian, begitu, serupa itu, sekali, tidak, tidaklah, tidak, hanya, saja, baru, cuma, semata-mata, melulu, doang, doangan, kemudian, sesudah itu, maka, lalu, setelah itu, waktu itu, pun, terus, teralu, juga, pun, sangat, terlampau, pula, kelewat, sekali, benar-benar, jua, sangat, amat, begitu, banget, benar, seluruh]
+preposition: 
+    - [dari, di, oleh, dengan, menurut, untuk, bagi, selama, dengan, bersama, pada, tentang, megenai, soal, terhadap, di sekitar, melawan, terhadap menentang, antara, di antara, ke, menjadi, ke dalam, melalui, lewat, melewati, sampai, selama, semasa, sementara,  sebelum, daripada, sebelum, di hadapan, di depan, di muka, stelah, sesudah, demi, sehabis, atas,  di atas, bawah, di bawah, ke, dari, naik, ke atas, menaikkan, turun, ke bawah, di bawah, turun, menurunkan, menjatuhkan, meletakkan, di, dalam, pada, di dalam, dengan, secara, untuk, lagi, di luar, ke luar, luar, pingsan, hanyut, lebih, di atas, ke atas, lagi, sisa, tersisa, dibawah, di bawah, bawah, lagi, kembali, sekali lagi, pula, lebih lanjut, lebih jauh, selanjutnya,  dari, daripada, kecuali, kepada]
+adjectives: 
+    - [sendiri, kepunyaan sendiri, sama, serupa, sama saja] 
+time: 
+    # added
+    - [menit, detik, jam, pukul, saat, waktu, bulan, tahun,  abad, kurun, am, pm, hari]
+    - [januari, februari, maret, april, april, mei, juni, juli, agustus, september, oktober, november, desember, jan, feb, mar, apr, mei, jun, jul, aug, sep, sept, okt, nov, des]
+number:
+    - [satu, dua, tiga, empat, lima, enam, tujuj, delapan, sembilan, sepuluh]
 

--- a/yaml/stopwords_id.yml
+++ b/yaml/stopwords_id.yml
@@ -2,56 +2,65 @@
 
 pronoun: 
     basic: 
-        # [i, me, myself, we, ours, ourselves, you, yours, yourself, yourselves, he, him, himself, she, hers, herself, it, itself, they, them, theirs, themselves, this, that, these, those]
-        - [saya, aku, gue, diri, sendiri, kita, kami, anda, kamu, engkau, saudara, milikmu, dirimu, dia, ia, beliau, kepunyaannya, punyanya, itu, ini, mereka, bahwa, yang, sehingga, agar, kalau, supaya, maka, bahwasanya, agar supaya, di waktu mana]
+        # [i, me, myself, we, ours, ourselves, you, yours, yourself, yourselves, he, him, himself, she, hers, herself]
+        - [saya, aku, gue, sendiri, kita, kami, anda, kamu, engkau, saudara, milikmu, dirimu, dia, ia, beliau, kepunyaannya, punya*]
+        # [it, itself, they, them, theirs, themselves, this, that, these, those]
+        - [itu, ini, mereka, bahwa*, yang]
     possesive: 
         # [my, our, your, his, her, its, their][my, our, your, his, her, its, their]
         - [milikku, milik saya, milik*]
     interogative: 
         # [what, which, who, whom, whose, when, where, why, how]
-        - [apa, mana, siapa, siapapun, kapan, ketika, jika, waktu, sewaktu, bila, apabila, dimana, ke, dari, padahal, mengapa, kenapa, kok, bagaimana, berapa]
+        - [apa, mana, siapa*, kapan, ketika, mengapa, kenapa, bagaimana]
     contraction: 
         # [i'm, you're, he's, she's, it's, we're, they're, i've, you've, we've, they've, i'd, you'd, he'd, she'd, we'd, they'd, i'll, you'll, he'll, she'll, we'll, they'll]
-        - [inilah, itulah, sudah, punya, akan, ingin]
+        - [sudah]
 verb: 
     basic: 
         # [am, is, are, was, were, be, been, being, have, has, had, having, do, does, did, doing]
-        - [adalah, ialah, dulu, menjadi, ada, berada, telah, mendapat, melakukan, berbuat, membuat, buat, dilakukan, perbuatan, merupakan]
+        - [adalah, dulu, menjadi,berada, telah, makhluk, melakukan, berbuat, dilakukan, perbuatan]
     modal: 
         # [would, should, could, ought, will]
-        - []
+        - [akan, harus, bisa, seharusnya]
     contraction: 
         # [isn't, aren't, wasn't, weren't, hasn't, haven't, hadn't, doesn't, don't, didn't, won't, wouldn't, shan't, shouldn't, can't, cannot, couldn't, mustn't, let's, that's, who's, what's, here's, there's, when's, where's, why's, how's]
-        - [tidak, bukan, jangan, tak, tidak akan, tidak bisa, tdk dapat, tdk bisa, tidak harus, ayo, siapa yang, disini adalah, adah, adalah, kapan, dimana, kenapa, bagaimana, hal]
+        - [tidak, bukan, jangan, tak, tidak akan, tidak bisa, tdk dapat, tdk bisa, tidak harus, siapa yang, adah, dimana]
     reporting: 
-        # [say, says, said, tell, tells, told, report, reports, reported]
-        - [mengatakan, kata, berkata, mengucapkan, berucap, ujar, berpendapat, bilang, membilangkan, mengomong, memprikan, mengira, tersebut, yang disebut di atas, menceritakan, menyuruh, bercerita, mengetahui, mengenali, mengenal, menunjukkan, menandakan, jelaskan, mengadukan, deberitahu, melapor*, mengabarkan, memberitahu*, mewartakan, lapor, merencana, unjuk bertahu, laporan, warta, renana, repot, dilaporkan]
+        # [say, says, said, tell, tells, told]
+        - [mengatakan, kata*, berkata, mengucapkan, berucap, ujar, berpendapat, bilang, membilangkan, mengomong, memprikan,mengira, menceritakan, menyuruh, bercerita, mengetahui, mengenal*, menunjukkan]
+        # [report, reports, reported]
+        - [jelaskan, deberitahu, melapor*, mengabarkan, memberitahu*, mewartakan, lapor*, merencana, repot, dilaporkan]
 article: 
     # [a, an, the]
-    - [sebuah, seorang, sebatang, itu, sang]
+    - [sebuah, sebatang, sang]
 conjunction:
     # [and, but, if, or, because, so, while, nor]
-    - [dan, serta, dengan, tambah, tetapi, melainkan, rupanya, jika, apakah, bila, atau, karena, sebab, begitu, amat, jadi, demikian, sementara, sedangkan, sambil, meski*, sembari, walaupun, seraya, saat, maupun, namun]
+    - [dan, serta, dengan, tambah, tetapi, melainkan, jika, atau, karena, sebab, begitu, amat, jadi, demikian, sementara, sedangkan, sambil, meski*, walaupun, maupun, namun]
 adverb: 
-    # [as, until, once, here, there, all, any, both, each, few, many, more, most, other, some, such, "no", not, only, then, too, very, little, less]
-    - [sebagai, seperti, ajak, sampai, sehingga, hingga, sekali, pernah, begini, sana, sekian, semua, segenap, segela, sekalian, sesuatu, kedua*, tiap*, masing*, beberapa, sedikit, tidak banyak, tdk banyak, banyak, lebih, lagi, tambah, menang, paling, sangat, amat, terlebih, lain, satu lagi, salah, salah satu, stengah, hebat, sedemikian, hanya, saja, baru, cuma, semata*, melulu, kemudian,  terus, teralu, pula, kelewat, benar*, banget, benar, seluruh]
+    # [as, until, once, here, there, all, any, both, each, few, many, more, most]
+    - [sebagai, seperti, ajak, sampai, sehingga, hingga, sekali, sini, sana, semua, segenap, segela, sekalian, sesuatu, kedua*, tiap*, masing*, banyak, lebih banyak]
+    # [other, some, such, "no", not, only, then, too, very, little, less]
+    - [lain, beberapa, hanya, saja, cuma, sedikit, tidak banyak]
 preposition: 
-    # [of, at, by, for, with, about, against, between, into, through, during, before, after, above, below, to, from, up, down, in, out, "on", "off", over, under, again, further, than]
-    - [di, oleh, dengan, menurut, untuk, bagi, selama, dengan, bersama, pada, tentang, megenai, soal, terhadap, di sekitar, melawan,  antara, di antara, menjadi, ke dalam, melalui, melewat*, sebelum, daripada, atas, bawah, naik, menaikkan, menurunkan, menjatuhkan, meletakkan, hanyut, lebih,  kembali, sekali lagi, pula, selanjutnya]
+    # [of, at, by, for, with, about, against, between, into, through, during]
+    - [di, oleh, dengan, menurut, untuk, bagi, dengan, pada, tentang, terhadap, antara, di antara, ke dalam, melalui, melewat*]
+    # [before, after, above, below, to, from, up, down, in, out, "on", "off", over, under, again, further, than]
+    - [sebelum, stelah, atas, bawah, ke, dari, naik, turun, dalam, luar, di atas, di bawah,  lagi, lebih lanjut, daripada]
 adjectives: 
     # [own, same] 
-    - [sendiri, kepunyaan sendiri, sama, serupa, sama saja] 
+    - [sendiri, sama] 
 time:
     # [minute, hour, month, year, century, am, pm]
-    - [menit, detik, jam, pukul, saat, waktu, bulan, tahun, abad, am, pm, hari]
+    - [menit, detik, jam, pukul, saat, waktu, bulan, tahun, abad, am, pm]
     # [january, february, march, april, may, june, july, august, september, october, november, december, jan, feb, mar, apr, may, jun, jul, aug, sep, sept, oct, nov, dec]
     - [januari, februari, maret, april, mei, juni, juli, agustus, september, oktober, november, desember, jan, feb, mar, apr, jun, jul, aug, sep, sept, okt, nov, des]
     # [sunday, monday, tuesday, wednesday, thursday, friday, saturday]
+    - [Minggu, Senin, Selasa, Rabu, Kamis, Jumat, Sabtu]
 number:
     cardinal:
         # [one, two, three, four, five, six, seven, eight, nine, ten]
         - [satu, dua, tiga, empat, lima, enam, tujuj, delapan, sembilan, sepuluh]
     ordinal: 
         # [first, second, third, fourth, fifth, seventh, eighth, nineth, tenth]
-        - []
+        - [pertama, kedua, ketiga, keempat, kelima, ketujuh, kedelapan, kesembilan, kesepuluh]
 

--- a/yaml/stopwords_id.yml
+++ b/yaml/stopwords_id.yml
@@ -1,0 +1,41 @@
+# Created by Hirokoi Kinoshita for the marimo stopwords: https://github.com/koheiw/marimo
+
+stopwords:
+    pronoun: 
+        basic: 
+            - [saya, aku, gue, daku, diri, diri sendiri, sendiri, saya sendiri, kita, kami, milik kita, milik kami, punya kami, anda, kamu, kau, kalian, engkau, saudara, milikmu, milik anda, milik kamu, dirimu sendiri, dia, ia, beliau, himself, kepunyaannya, punyanya, itu, ini, mereka, milik mereka, punya mereka, mereka empunya, yang ini, bahwa, yang, sehingga, agar, kalau, supaya, maka, bahwasanya, agar supaya, di waktu mana]
+        possesive: 
+            - [saya,  milikku, milik saya, kami, kita, Anda, kamu, saudara, kau, engkau, dia, ia, mereka, para]
+        interogative: 
+            # added "whose"
+            - [apa, yang, mana, alangkah, mana saja, siapa, siapa saja, siapapun, kapan, ketika, jika, kapan, waktu, kalau, sewaktu, bila, apabila, bilamana, dimana, ke mana, dari mana, dimana, padahal, mengapa, kenapa, kok, apa sebab, sebab, bagaimana, berapa, betapa, bagaimana caranya, cara, metode, macam]
+        contraction: 
+            - [saya, kamu adalah, dia adalah, ia adalah, ini, itulah, sekarang, kita, kami, mereka, saya sudah, saya punya, kami punya, anda punya, kita punya, mereka punya, saya akan, saya ingin, kamu akan, anda akan, anda ingin, dia akan, dia ingin, ia akan, ia ingin, kita akan, kita ingin, kami akan, kami ingin, mereka akan, mereka ingin, saya akan, aku akan, kamu akan, anda akan, ia akan, dia akan, kami akan, kita akan, mereka akan, kh, KH, sudah]
+    verb: 
+        basic: 
+            - [adalah, ialah, dulu, dulu, menjadi, ada, berada, telah, memiliki, mempunyai, ada, mendapat, punya, memiliki, mempunyai, melakukan, berbuat, membuat, buat, dilakukan, perbuatan,merupakan]
+        modal: 
+            - [akan, sebaiknya, harus, seharusnya, sebaiknya, semestinya, patut, bisa, dapat, mungkin, mau, siap, barangkali, seharusnya, patut, lebih baik, akan, bekal, biasa, mungkin]
+        contraction: 
+            - [tidak, tidak, tidak, tidak, bukan, tidak punya, tidak punya, tidak punya, tidak, jangan, tak, tidak akan, tidak akan, jangan, tidak bisa, tdk dapat, tdk bisa, tidak harus, ayo, itu adalah, siapa yang, apa yang, disini adalah, adah, adalah, kapan, dimana, kenapa, bagaimana,hal]
+        reporting: 
+            # added
+            - [mengatakan, kata, berkata, mengucapkan, berucap, ujar, berpendapat, bilang, membilangkan, mengomong, memprikan, mengira, kata, tersebut, yg disebut di atas, yang disebut di atas, menceritakan, mengatakan, menyuruh, memberitahukan, bercerita, mengetahui, mengenali, mengenal, menunjukkan, menandakan, jelaskan, mengadukan, deberitahu, melaporkan, melapor, mengabarkan, memberitahu, mewartakan, lapor, merencana, unjuk bertahu, laporan, warta, renana, repot, dilaporkan]
+    article: 
+        - [sebuah, seorang, sebatang, itu, sang]
+    conjunction: 
+        - [dan, serta, dengan, en, tambah, tapi, tetapi, melainkan, akan tetapi, meskipun begitu, rupanya, jika, apakah, kalau, bila, apabila, jikalau, atau, karena, sebab, lantaran, begitu, amat, jadi, demikian, juga, sekali, jua, sementara, sedangkan, selagi, sambil, waktu, meskipun, sembari, walaupun, meski, seraya, saat, maupun, namun]
+    adverb: 
+        # added "many"
+        - [sebagai, karena, ketika, betapa, seperti, ajak, sampai, sehingga, hingga, sekali, pernah, sini, di sini, ke sini, ke mari, begini, ini, sana, di sana, ke sana, situ, di situ, ke situ, sekian, sang, semua, segenap, segela, sekalian, apa saja, apa pun, sesuatu, siapa saja, barang, apa-apa, kedua, keduanya, berdua, kedua-duanya, setiap, tiap, tiap-tiap, masing-masing, beberapa, sedikit, tidak banyak, tdk banyak, banyak, lebih, lagi, tambah, menang, paling, sangat, amat, terlebih, lain, satu lagi, beberapa, salah, salah satu, suatu, stengah, hebat, seperti, seperti itu, sedemikian, begitu, serupa itu, sekali, tidak, tidaklah, tidak, hanya, saja, baru, cuma, semata-mata, melulu, doang, doangan, kemudian, sesudah itu, maka, lalu, setelah itu, waktu itu, pun, terus, teralu, juga, pun, sangat, terlampau, pula, kelewat, sekali, benar-benar, jua, sangat, amat, begitu, banget, benar, seluruh]
+    preposition: 
+        - [dari, di, oleh, dengan, menurut, untuk, bagi, selama, dengan, bersama, pada, tentang, megenai, soal, terhadap, di sekitar, melawan, terhadap menentang, antara, di antara, ke, menjadi, ke dalam, melalui, lewat, melewati, sampai, selama, semasa, sementara,  sebelum, daripada, sebelum, di hadapan, di depan, di muka, stelah, sesudah, demi, sehabis, atas,  di atas, bawah, di bawah, ke, dari, naik, ke atas, menaikkan, turun, ke bawah, di bawah, turun, menurunkan, menjatuhkan, meletakkan, di, dalam, pada, di dalam, dengan, secara, untuk, lagi, di luar, ke luar, luar, pingsan, hanyut, lebih, di atas, ke atas, lagi, sisa, tersisa, dibawah, di bawah, bawah, lagi, kembali, sekali lagi, pula, lebih lanjut, lebih jauh, selanjutnya,  dari, daripada, kecuali, kepada]
+    adjectives: 
+        - [sendiri, kepunyaan sendiri, sama, serupa, sama saja] 
+    time: 
+        # added
+        - [menit, detik, jam, pukul, saat, waktu, bulan, tahun,  abad, kurun, am, pm, hari]
+        - [januari, februari, maret, april, april, mei, juni, juli, agustus, september, oktober, november, desember, jan, feb, mar, apr, mei, jun, jul, aug, sep, sept, okt, nov, des]
+    number:
+        - [satu, dua, tiga, empat, lima, enam, tujuj, delapan, sembilan, sepuluh]
+

--- a/yaml/stopwords_id.yml
+++ b/yaml/stopwords_id.yml
@@ -24,7 +24,7 @@ verb:
         - [akan, harus, bisa, seharusnya]
     contraction: 
         # [isn't, aren't, wasn't, weren't, hasn't, haven't, hadn't, doesn't, don't, didn't, won't, wouldn't, shan't, shouldn't, can't, cannot, couldn't, mustn't, let's, that's, who's, what's, here's, there's, when's, where's, why's, how's]
-        - [tidak, bukan, jangan, tak, tidak akan, tidak bisa, tidak harus, siapa yang, adah, dimana]
+    
     reporting: 
         # [say, says, said, tell, tells, told]
         - [mengatakan, kata*, berkata, mengucapkan, berucap, ujar, berpendapat, bilang, membilangkan, mengomong, memprikan,mengira, menceritakan, menyuruh, bercerita, mengetahui, mengenal*, menunjukkan]
@@ -40,7 +40,7 @@ adverb:
     # [as, until, once, here, there, all, any, both, each, few, many, more, most]
     - [sebagai, seperti, ajak, sampai, sehingga, hingga, sekali, sini, sana, semua, segenap, segela, sekalian, sesuatu, kedua*, tiap*, masing*, banyak, lebih banyak]
     # [other, some, such, "no", not, only, then, too, very, little, less]
-    - [lain, beberapa, hanya, "tidak", saja, cuma, sangat, sedikit, tidak banyak]
+    - [lain, beberapa, hanya, "tidak", "bukan", saja, cuma, sangat, sedikit, tidak banyak]
 preposition: 
     # [of, at, by, for, with, about, against, between, into, through, during]
     - [di, oleh, dengan, menurut, untuk, bagi, dengan, pada, tentang, terhadap, antara, di antara, ke dalam, melalui, melewat*]

--- a/yaml/stopwords_id.yml
+++ b/yaml/stopwords_id.yml
@@ -48,8 +48,10 @@ time:
     - [januari, februari, maret, april, mei, juni, juli, agustus, september, oktober, november, desember, jan, feb, mar, apr, jun, jul, aug, sep, sept, okt, nov, des]
     # [sunday, monday, tuesday, wednesday, thursday, friday, saturday]
 number:
-    # [one, two, three, four, five, six, seven, eight, nine, ten]
-    - [satu, dua, tiga, empat, lima, enam, tujuj, delapan, sembilan, sepuluh]
-    # [first, second, third, fourth, fifth, seventh, eighth, nineth, tenth]
-    - []
+    cardinal:
+        # [one, two, three, four, five, six, seven, eight, nine, ten]
+        - [satu, dua, tiga, empat, lima, enam, tujuj, delapan, sembilan, sepuluh]
+    ordinal: 
+        # [first, second, third, fourth, fifth, seventh, eighth, nineth, tenth]
+        - []
 

--- a/yaml/stopwords_id.yml
+++ b/yaml/stopwords_id.yml
@@ -33,7 +33,7 @@ stopwords:
         - [sendiri, kepunyaan sendiri, sama, serupa, sama saja] 
     time: v
         # added
-        - [menit, detik, jam, pukul, saat, waktu, bulan, tahun,  abad, kurun, am, pm, hari]
+        - [menit, detik, jam, pukul, saat, waktu, bulan, tahun, abad, am, pm, hari]
         - [januari, februari, maret, april, mei, juni, juli, agustus, september, oktober, november, desember, jan, feb, mar, apr, jun, jul, aug, sep, sept, okt, nov, des]
     number:
         - [satu, dua, tiga, empat, lima, enam, tujuj, delapan, sembilan, sepuluh]

--- a/yaml/stopwords_id.yml
+++ b/yaml/stopwords_id.yml
@@ -1,4 +1,4 @@
-# Created by Hirokoi Kinoshita for the marimo stopwords: https://github.com/koheiw/marimo
+# Created by Hiroko Kinoshita for the marimo stopwords: https://github.com/koheiw/marimo
 
 stopwords:
     pronoun: 

--- a/yaml/stopwords_id.yml
+++ b/yaml/stopwords_id.yml
@@ -1,39 +1,41 @@
 # Created by Hirokoi Kinoshita for the marimo stopwords: https://github.com/koheiw/marimo
-pronoun: 
-    basic: 
-        - [saya, aku, gue, daku, diri, diri sendiri, sendiri, saya sendiri, kita, kami, milik kita, milik kami, punya kami, anda, kamu, kau, kalian, engkau, saudara, milikmu, milik anda, milik kamu, dirimu sendiri, dia, ia, beliau, himself, kepunyaannya, punyanya, itu, ini, mereka, milik mereka, punya mereka, mereka empunya, yang ini, bahwa, yang, sehingga, agar, kalau, supaya, maka, bahwasanya, agar supaya, di waktu mana]
-    possesive: 
-        - [saya,  milikku, milik saya, kami, kita, Anda, kamu, saudara, kau, engkau, dia, ia, mereka, para]
-    interogative: 
-        # added "whose"
-        - [apa, yang, mana, alangkah, mana saja, siapa, siapa saja, siapapun, kapan, ketika, jika, kapan, waktu, kalau, sewaktu, bila, apabila, bilamana, dimana, ke mana, dari mana, dimana, padahal, mengapa, kenapa, kok, apa sebab, sebab, bagaimana, berapa, betapa, bagaimana caranya, cara, metode, macam]
-    contraction: 
-        - [saya, kamu adalah, dia adalah, ia adalah, ini, itulah, sekarang, kita, kami, mereka, saya sudah, saya punya, kami punya, anda punya, kita punya, mereka punya, saya akan, saya ingin, kamu akan, anda akan, anda ingin, dia akan, dia ingin, ia akan, ia ingin, kita akan, kita ingin, kami akan, kami ingin, mereka akan, mereka ingin, saya akan, aku akan, kamu akan, anda akan, ia akan, dia akan, kami akan, kita akan, mereka akan, kh, KH, sudah]
-verb: 
-    basic: 
-        - [adalah, ialah, dulu, dulu, menjadi, ada, berada, telah, memiliki, mempunyai, ada, mendapat, punya, memiliki, mempunyai, melakukan, berbuat, membuat, buat, dilakukan, perbuatan,merupakan]
-    modal: 
-        - [akan, sebaiknya, harus, seharusnya, sebaiknya, semestinya, patut, bisa, dapat, mungkin, mau, siap, barangkali, seharusnya, patut, lebih baik, akan, bekal, biasa, mungkin]
-    contraction: 
-        - [tidak, tidak, tidak, tidak, bukan, tidak punya, tidak punya, tidak punya, tidak, jangan, tak, tidak akan, tidak akan, jangan, tidak bisa, tdk dapat, tdk bisa, tidak harus, ayo, itu adalah, siapa yang, apa yang, disini adalah, adah, adalah, kapan, dimana, kenapa, bagaimana,hal]
-    reporting: 
+
+stopwords:
+    pronoun: 
+        basic: 
+            - [saya, aku, gue, diri, diri sendiri, sendiri, kita, kami, milik kita, milik kami, punya kami, anda, kamu, engkau, saudara, milikmu, milik anda, milik kamu, dirimu, dia, ia, beliau, kepunyaannya, punyanya, itu, ini, mereka, milik mereka, punya mereka, yang ini, bahwa, yang, sehingga, agar, kalau, supaya, maka, bahwasanya, agar supaya, di waktu mana]
+        possesive: 
+            - [milikku, milik saya, milik*]
+        interogative: 
+            # added "whose"
+            - [apa, yang, mana, siapa, siapapun, kapan, ketika, jika, waktu, kalau, sewaktu, bila, apabila, dimana, ke, dari, padahal, mengapa, kenapa, kok, bagaimana, berapa]
+        contraction: 
+            - [saya, kamu, dia, ia, ini, itulah, kita, kami, mereka, saya sudah, saya punya, kami punya, anda punya, kita punya, mereka punya, saya akan, saya ingin, kamu akan, anda akan, anda ingin, dia akan, dia ingin, ia akan, ia ingin, kita akan, kita ingin, kami akan, kami ingin, mereka akan, mereka ingin]
+    verb: 
+        basic: 
+            - [adalah, ialah, dulu, dulu, menjadi, ada, berada, telah, memiliki, mempunyai, mendapat, punya, melakukan, berbuat, membuat, buat, dilakukan, perbuatan, merupakan]
+        modal: 
+            - [akan, sebaiknya, harus, seharusnya, sebaiknya, semestinya, patut, bisa, dapat, mungkin, mau, siap, barangkali, seharusnya]
+        contraction: 
+            - [tidak, bukan, tidak punya, jangan, tak, tidak akan, tidak bisa, tdk dapat, tdk bisa, tidak harus, ayo, itu adalah, siapa yang, apa yang, disini adalah, adah, adalah, kapan, dimana, kenapa, bagaimana, hal]
+        reporting: 
+            # added
+            - [mengatakan, kata, berkata, mengucapkan, berucap, ujar, berpendapat, bilang, membilangkan, mengomong, memprikan, mengira, tersebut, yang disebut di atas, menceritakan, menyuruh, bercerita, mengetahui, mengenali, mengenal, menunjukkan, menandakan, jelaskan, mengadukan, deberitahu, melapor*, mengabarkan, memberitahu*, mewartakan, lapor, merencana, unjuk bertahu, laporan, warta, renana, repot, dilaporkan]
+    article: 
+        - [sebuah, seorang, sebatang, itu, sang]
+    conjunction: 
+        - [dan, serta, dengan, tambah, tapi, tetapi, melainkan, akan tetapi, meskipun begitu, rupanya, jika, apakah, kalau, bila, apabila, jikalau, atau, karena, sebab, lantaran, begitu, amat, jadi, demikian, juga, sekali, sementara, sedangkan, selagi, sambil, meski*, sembari, walaupun, seraya, saat, maupun, namun]
+    adverb: 
+        # added "many"
+        - [sebagai, karena, ketika, betapa, seperti, ajak, sampai, sehingga, hingga, sekali, pernah, sini, di sini, ke sini, begini, ini, sana, di sana, ke sana, situ, di situ, ke situ, sekian, semua, segenap, segela, sekalian, apa saja, apa pun, sesuatu, siapa saja, barang, apa-apa, kedua*, berdua, setiap, tiap*, masing*, beberapa, sedikit, tidak banyak, tdk banyak, banyak, lebih, lagi, tambah, menang, paling, sangat, amat, terlebih, lain, satu lagi, salah, salah satu, suatu, stengah, hebat, seperti itu, sedemikian, begitu, serupa itu, sekali, tidaklah, tidak, hanya, saja, baru, cuma, semata*, melulu, kemudian, sesudah itu, maka, lalu, setelah itu, waktu itu, pun, terus, teralu, juga, pun, sangat, terlampau, pula, kelewat, benar*, jua, sangat, amat, begitu, banget, benar, seluruh]
+    preposition: 
+        - [dari, di, oleh, dengan, menurut, untuk, bagi, selama, dengan, bersama, pada, tentang, megenai, soal, terhadap, di sekitar, melawan, terhadap menentang, antara, di antara, ke, menjadi, ke dalam, melalui, lewat, melewat*, sampai, selama, sementara, sebelum, daripada, di hadapan, di depan, di muka, stelah, sesudah, sehabis, atas,  di atas, bawah, di bawah, ke, dari, naik, ke atas, menaikkan, turun, ke bawah, di bawah, turun, menurunkan, menjatuhkan, meletakkan, di, dalam, pada, di dalam, dengan, secara, untuk, lagi, di luar, ke luar, luar, pingsan, hanyut, lebih, di atas, ke atas, lagi, sisa, tersisa, dibawah, di bawah, bawah, lagi, kembali, sekali lagi, pula, lebih lanjut, lebih jauh, selanjutnya, daripada, kecuali, kepada]
+    adjectives: 
+        - [sendiri, kepunyaan sendiri, sama, serupa, sama saja] 
+    time: 
         # added
-        - [mengatakan, kata, berkata, mengucapkan, berucap, ujar, berpendapat, bilang, membilangkan, mengomong, memprikan, mengira, kata, tersebut, yg disebut di atas, yang disebut di atas, menceritakan, mengatakan, menyuruh, memberitahukan, bercerita, mengetahui, mengenali, mengenal, menunjukkan, menandakan, jelaskan, mengadukan, deberitahu, melaporkan, melapor, mengabarkan, memberitahu, mewartakan, lapor, merencana, unjuk bertahu, laporan, warta, renana, repot, dilaporkan]
-article: 
-    - [sebuah, seorang, sebatang, itu, sang]
-conjunction: 
-    - [dan, serta, dengan, en, tambah, tapi, tetapi, melainkan, akan tetapi, meskipun begitu, rupanya, jika, apakah, kalau, bila, apabila, jikalau, atau, karena, sebab, lantaran, begitu, amat, jadi, demikian, juga, sekali, jua, sementara, sedangkan, selagi, sambil, waktu, meskipun, sembari, walaupun, meski, seraya, saat, maupun, namun]
-adverb: 
-    # added "many"
-    - [sebagai, karena, ketika, betapa, seperti, ajak, sampai, sehingga, hingga, sekali, pernah, sini, di sini, ke sini, ke mari, begini, ini, sana, di sana, ke sana, situ, di situ, ke situ, sekian, sang, semua, segenap, segela, sekalian, apa saja, apa pun, sesuatu, siapa saja, barang, apa-apa, kedua, keduanya, berdua, kedua-duanya, setiap, tiap, tiap-tiap, masing-masing, beberapa, sedikit, tidak banyak, tdk banyak, banyak, lebih, lagi, tambah, menang, paling, sangat, amat, terlebih, lain, satu lagi, beberapa, salah, salah satu, suatu, stengah, hebat, seperti, seperti itu, sedemikian, begitu, serupa itu, sekali, tidak, tidaklah, tidak, hanya, saja, baru, cuma, semata-mata, melulu, doang, doangan, kemudian, sesudah itu, maka, lalu, setelah itu, waktu itu, pun, terus, teralu, juga, pun, sangat, terlampau, pula, kelewat, sekali, benar-benar, jua, sangat, amat, begitu, banget, benar, seluruh]
-preposition: 
-    - [dari, di, oleh, dengan, menurut, untuk, bagi, selama, dengan, bersama, pada, tentang, megenai, soal, terhadap, di sekitar, melawan, terhadap menentang, antara, di antara, ke, menjadi, ke dalam, melalui, lewat, melewati, sampai, selama, semasa, sementara,  sebelum, daripada, sebelum, di hadapan, di depan, di muka, stelah, sesudah, demi, sehabis, atas,  di atas, bawah, di bawah, ke, dari, naik, ke atas, menaikkan, turun, ke bawah, di bawah, turun, menurunkan, menjatuhkan, meletakkan, di, dalam, pada, di dalam, dengan, secara, untuk, lagi, di luar, ke luar, luar, pingsan, hanyut, lebih, di atas, ke atas, lagi, sisa, tersisa, dibawah, di bawah, bawah, lagi, kembali, sekali lagi, pula, lebih lanjut, lebih jauh, selanjutnya,  dari, daripada, kecuali, kepada]
-adjectives: 
-    - [sendiri, kepunyaan sendiri, sama, serupa, sama saja] 
-time: 
-    # added
-    - [menit, detik, jam, pukul, saat, waktu, bulan, tahun,  abad, kurun, am, pm, hari]
-    - [januari, februari, maret, april, april, mei, juni, juli, agustus, september, oktober, november, desember, jan, feb, mar, apr, mei, jun, jul, aug, sep, sept, okt, nov, des]
-number:
-    - [satu, dua, tiga, empat, lima, enam, tujuj, delapan, sembilan, sepuluh]
+        - [menit, detik, jam, pukul, saat, waktu, bulan, tahun,  abad, kurun, am, pm, hari]
+        - [januari, februari, maret, april, april, mei, juni, juli, agustus, september, oktober, november, desember, jan, feb, mar, apr, mei, jun, jul, aug, sep, sept, okt, nov, des]
+    number:
+        - [satu, dua, tiga, empat, lima, enam, tujuj, delapan, sembilan, sepuluh]
 

--- a/yaml/stopwords_id.yml
+++ b/yaml/stopwords_id.yml
@@ -3,39 +3,38 @@
 stopwords:
     pronoun: 
         basic: 
-            - [saya, aku, gue, diri, diri sendiri, sendiri, kita, kami, milik kita, milik kami, punya kami, anda, kamu, engkau, saudara, milikmu, milik anda, milik kamu, dirimu, dia, ia, beliau, kepunyaannya, punyanya, itu, ini, mereka, milik mereka, punya mereka, yang ini, bahwa, yang, sehingga, agar, kalau, supaya, maka, bahwasanya, agar supaya, di waktu mana]
+            - [saya, aku, gue, diri, sendiri, kita, kami, anda, kamu, engkau, saudara, milikmu, dirimu, dia, ia, beliau, kepunyaannya, punyanya, itu, ini, mereka, bahwa, yang, sehingga, agar, kalau, supaya, maka, bahwasanya, agar supaya, di waktu mana]
         possesive: 
             - [milikku, milik saya, milik*]
         interogative: 
             # added "whose"
-            - [apa, yang, mana, siapa, siapapun, kapan, ketika, jika, waktu, kalau, sewaktu, bila, apabila, dimana, ke, dari, padahal, mengapa, kenapa, kok, bagaimana, berapa]
+            - [apa, mana, siapa, siapapun, kapan, ketika, jika, waktu, sewaktu, bila, apabila, dimana, ke, dari, padahal, mengapa, kenapa, kok, bagaimana, berapa]
         contraction: 
-            - [saya, kamu, dia, ia, ini, itulah, kita, kami, mereka, saya sudah, saya punya, kami punya, anda punya, kita punya, mereka punya, saya akan, saya ingin, kamu akan, anda akan, anda ingin, dia akan, dia ingin, ia akan, ia ingin, kita akan, kita ingin, kami akan, kami ingin, mereka akan, mereka ingin]
+            - [inilah, itulah, sudah, punya, akan, ingin]
     verb: 
         basic: 
-            - [adalah, ialah, dulu, dulu, menjadi, ada, berada, telah, memiliki, mempunyai, mendapat, punya, melakukan, berbuat, membuat, buat, dilakukan, perbuatan, merupakan]
+            - [adalah, ialah, dulu, menjadi, ada, berada, telah, mendapat, melakukan, berbuat, membuat, buat, dilakukan, perbuatan, merupakan]
         modal: 
-            - [akan, sebaiknya, harus, seharusnya, sebaiknya, semestinya, patut, bisa, dapat, mungkin, mau, siap, barangkali, seharusnya]
         contraction: 
-            - [tidak, bukan, tidak punya, jangan, tak, tidak akan, tidak bisa, tdk dapat, tdk bisa, tidak harus, ayo, itu adalah, siapa yang, apa yang, disini adalah, adah, adalah, kapan, dimana, kenapa, bagaimana, hal]
+            - [tidak, bukan, jangan, tak, tidak akan, tidak bisa, tdk dapat, tdk bisa, tidak harus, ayo, siapa yang, disini adalah, adah, adalah, kapan, dimana, kenapa, bagaimana, hal]
         reporting: 
             # added
             - [mengatakan, kata, berkata, mengucapkan, berucap, ujar, berpendapat, bilang, membilangkan, mengomong, memprikan, mengira, tersebut, yang disebut di atas, menceritakan, menyuruh, bercerita, mengetahui, mengenali, mengenal, menunjukkan, menandakan, jelaskan, mengadukan, deberitahu, melapor*, mengabarkan, memberitahu*, mewartakan, lapor, merencana, unjuk bertahu, laporan, warta, renana, repot, dilaporkan]
     article: 
         - [sebuah, seorang, sebatang, itu, sang]
-    conjunction: 
-        - [dan, serta, dengan, tambah, tapi, tetapi, melainkan, akan tetapi, meskipun begitu, rupanya, jika, apakah, kalau, bila, apabila, jikalau, atau, karena, sebab, lantaran, begitu, amat, jadi, demikian, juga, sekali, sementara, sedangkan, selagi, sambil, meski*, sembari, walaupun, seraya, saat, maupun, namun]
+    conjunction:
+        - [dan, serta, dengan, tambah, tetapi, melainkan, rupanya, jika, apakah, bila, atau, karena, sebab, begitu, amat, jadi, demikian, sementara, sedangkan, sambil, meski*, sembari, walaupun, seraya, saat, maupun, namun]
     adverb: 
         # added "many"
-        - [sebagai, karena, ketika, betapa, seperti, ajak, sampai, sehingga, hingga, sekali, pernah, sini, di sini, ke sini, begini, ini, sana, di sana, ke sana, situ, di situ, ke situ, sekian, semua, segenap, segela, sekalian, apa saja, apa pun, sesuatu, siapa saja, barang, apa-apa, kedua*, berdua, setiap, tiap*, masing*, beberapa, sedikit, tidak banyak, tdk banyak, banyak, lebih, lagi, tambah, menang, paling, sangat, amat, terlebih, lain, satu lagi, salah, salah satu, suatu, stengah, hebat, seperti itu, sedemikian, begitu, serupa itu, sekali, tidaklah, tidak, hanya, saja, baru, cuma, semata*, melulu, kemudian, sesudah itu, maka, lalu, setelah itu, waktu itu, pun, terus, teralu, juga, pun, sangat, terlampau, pula, kelewat, benar*, jua, sangat, amat, begitu, banget, benar, seluruh]
+        - [sebagai, seperti, ajak, sampai, sehingga, hingga, sekali, pernah, begini, sana, sekian, semua, segenap, segela, sekalian, sesuatu, kedua*, tiap*, masing*, beberapa, sedikit, tidak banyak, tdk banyak, banyak, lebih, lagi, tambah, menang, paling, sangat, amat, terlebih, lain, satu lagi, salah, salah satu, stengah, hebat, sedemikian, hanya, saja, baru, cuma, semata*, melulu, kemudian,  terus, teralu, pula, kelewat, benar*, banget, benar, seluruh]
     preposition: 
-        - [dari, di, oleh, dengan, menurut, untuk, bagi, selama, dengan, bersama, pada, tentang, megenai, soal, terhadap, di sekitar, melawan, terhadap menentang, antara, di antara, ke, menjadi, ke dalam, melalui, lewat, melewat*, sampai, selama, sementara, sebelum, daripada, di hadapan, di depan, di muka, stelah, sesudah, sehabis, atas,  di atas, bawah, di bawah, ke, dari, naik, ke atas, menaikkan, turun, ke bawah, di bawah, turun, menurunkan, menjatuhkan, meletakkan, di, dalam, pada, di dalam, dengan, secara, untuk, lagi, di luar, ke luar, luar, pingsan, hanyut, lebih, di atas, ke atas, lagi, sisa, tersisa, dibawah, di bawah, bawah, lagi, kembali, sekali lagi, pula, lebih lanjut, lebih jauh, selanjutnya, daripada, kecuali, kepada]
+        - [di, oleh, dengan, menurut, untuk, bagi, selama, dengan, bersama, pada, tentang, megenai, soal, terhadap, di sekitar, melawan,  antara, di antara, menjadi, ke dalam, melalui, melewat*, sebelum, daripada, atas, bawah, naik, menaikkan, menurunkan, menjatuhkan, meletakkan, hanyut, lebih,  kembali, sekali lagi, pula, selanjutnya]
     adjectives: 
         - [sendiri, kepunyaan sendiri, sama, serupa, sama saja] 
-    time: 
+    time: v
         # added
         - [menit, detik, jam, pukul, saat, waktu, bulan, tahun,  abad, kurun, am, pm, hari]
-        - [januari, februari, maret, april, april, mei, juni, juli, agustus, september, oktober, november, desember, jan, feb, mar, apr, mei, jun, jul, aug, sep, sept, okt, nov, des]
+        - [januari, februari, maret, april, mei, juni, juli, agustus, september, oktober, november, desember, jan, feb, mar, apr, jun, jul, aug, sep, sept, okt, nov, des]
     number:
         - [satu, dua, tiga, empat, lima, enam, tujuj, delapan, sembilan, sepuluh]
 

--- a/yaml/stopwords_id.yml
+++ b/yaml/stopwords_id.yml
@@ -40,7 +40,7 @@ adverb:
     # [as, until, once, here, there, all, any, both, each, few, many, more, most]
     - [sebagai, seperti, ajak, sampai, sehingga, hingga, sekali, sini, sana, semua, segenap, segela, sekalian, sesuatu, kedua*, tiap*, masing*, banyak, lebih, paling]
     # [other, some, such, "no", not, only, then, too, very, little, less]
-    - [lain, beberapa, hanya, "tidak", "bukan", saja, cuma, sangat, sedikit, tidak banyak]
+    - [lain, beberapa, hanya, "tidak", "bukan", saja, cuma, sangat, sedikit, banyak]
 preposition: 
     # [of, at, by, for, with, about, against, between, into, through, during]
     - [di, oleh, dengan, menurut, untuk, bagi, dengan, pada, tentang, terhadap, antara, di antara, ke dalam, melalui, melewat*]

--- a/yaml/stopwords_id.yml
+++ b/yaml/stopwords_id.yml
@@ -40,7 +40,7 @@ adverb:
     # [as, until, once, here, there, all, any, both, each, few, many, more, most]
     - [sebagai, seperti, ajak, sampai, sehingga, hingga, sekali, sini, sana, semua, segenap, segela, sekalian, sesuatu, kedua*, tiap*, masing*, banyak, lebih banyak]
     # [other, some, such, "no", not, only, then, too, very, little, less]
-    - [lain, beberapa, hanya, "tidak", saja, cuma, sedikit, tidak banyak]
+    - [lain, beberapa, hanya, "tidak", saja, cuma, sangat, sedikit, tidak banyak]
 preposition: 
     # [of, at, by, for, with, about, against, between, into, through, during]
     - [di, oleh, dengan, menurut, untuk, bagi, dengan, pada, tentang, terhadap, antara, di antara, ke dalam, melalui, melewat*]

--- a/yaml/stopwords_id.yml
+++ b/yaml/stopwords_id.yml
@@ -51,7 +51,7 @@ adjectives:
     - [sendiri, sama] 
 time:
     # [minute, hour, month, year, century, am, pm]
-    - [menit, detik, jam, pukul, saat, waktu, bulan, tahun, abad, am, pm]
+    - [menit, jam, pukul, saat, waktu, bulan, tahun, abad, am, pm]
     # [january, february, march, april, may, june, july, august, september, october, november, december, jan, feb, mar, apr, may, jun, jul, aug, sep, sept, oct, nov, dec]
     - [januari, februari, maret, april, mei, juni, juli, agustus, september, oktober, november, desember, jan, feb, mar, apr, jun, jul, aug, sep, sept, okt, nov, des]
     # [sunday, monday, tuesday, wednesday, thursday, friday, saturday]

--- a/yaml/stopwords_id.yml
+++ b/yaml/stopwords_id.yml
@@ -31,7 +31,7 @@ stopwords:
         - [di, oleh, dengan, menurut, untuk, bagi, selama, dengan, bersama, pada, tentang, megenai, soal, terhadap, di sekitar, melawan,  antara, di antara, menjadi, ke dalam, melalui, melewat*, sebelum, daripada, atas, bawah, naik, menaikkan, menurunkan, menjatuhkan, meletakkan, hanyut, lebih,  kembali, sekali lagi, pula, selanjutnya]
     adjectives: 
         - [sendiri, kepunyaan sendiri, sama, serupa, sama saja] 
-    time: v
+    time:
         # added
         - [menit, detik, jam, pukul, saat, waktu, bulan, tahun, abad, am, pm, hari]
         - [januari, februari, maret, april, mei, juni, juli, agustus, september, oktober, november, desember, jan, feb, mar, apr, jun, jul, aug, sep, sept, okt, nov, des]

--- a/yaml/stopwords_id.yml
+++ b/yaml/stopwords_id.yml
@@ -24,7 +24,7 @@ verb:
         - [akan, harus, bisa, seharusnya]
     contraction: 
         # [isn't, aren't, wasn't, weren't, hasn't, haven't, hadn't, doesn't, don't, didn't, won't, wouldn't, shan't, shouldn't, can't, cannot, couldn't, mustn't, let's, that's, who's, what's, here's, there's, when's, where's, why's, how's]
-        - [tidak, bukan, jangan, tak, tidak akan, tidak bisa, tdk dapat, tdk bisa, tidak harus, siapa yang, adah, dimana]
+        - [tidak, bukan, jangan, tak, tidak akan, tidak bisa, tidak harus, siapa yang, adah, dimana]
     reporting: 
         # [say, says, said, tell, tells, told]
         - [mengatakan, kata*, berkata, mengucapkan, berucap, ujar, berpendapat, bilang, membilangkan, mengomong, memprikan,mengira, menceritakan, menyuruh, bercerita, mengetahui, mengenal*, menunjukkan]
@@ -40,7 +40,7 @@ adverb:
     # [as, until, once, here, there, all, any, both, each, few, many, more, most]
     - [sebagai, seperti, ajak, sampai, sehingga, hingga, sekali, sini, sana, semua, segenap, segela, sekalian, sesuatu, kedua*, tiap*, masing*, banyak, lebih banyak]
     # [other, some, such, "no", not, only, then, too, very, little, less]
-    - [lain, beberapa, hanya, saja, cuma, sedikit, tidak banyak]
+    - [lain, beberapa, hanya, "tidak", saja, cuma, sedikit, tidak banyak]
 preposition: 
     # [of, at, by, for, with, about, against, between, into, through, during]
     - [di, oleh, dengan, menurut, untuk, bagi, dengan, pada, tentang, terhadap, antara, di antara, ke dalam, melalui, melewat*]

--- a/yaml/stopwords_id.yml
+++ b/yaml/stopwords_id.yml
@@ -38,14 +38,14 @@ conjunction:
     - [dan, serta, dengan, tambah, tetapi, melainkan, jika, atau, karena, sebab, begitu, amat, jadi, demikian, sementara, sedangkan, sambil, meski*, walaupun, maupun, namun]
 adverb: 
     # [as, until, once, here, there, all, any, both, each, few, many, more, most]
-    - [sebagai, seperti, ajak, sampai, sehingga, hingga, sekali, sini, sana, semua, segenap, segela, sekalian, sesuatu, kedua*, tiap*, masing*, banyak, lebih banyak]
+    - [sebagai, seperti, ajak, sampai, sehingga, hingga, sekali, sini, sana, semua, segenap, segela, sekalian, sesuatu, kedua*, tiap*, masing*, banyak, lebih, paling]
     # [other, some, such, "no", not, only, then, too, very, little, less]
     - [lain, beberapa, hanya, "tidak", "bukan", saja, cuma, sangat, sedikit, tidak banyak]
 preposition: 
     # [of, at, by, for, with, about, against, between, into, through, during]
     - [di, oleh, dengan, menurut, untuk, bagi, dengan, pada, tentang, terhadap, antara, di antara, ke dalam, melalui, melewat*]
     # [before, after, above, below, to, from, up, down, in, out, "on", "off", over, under, again, further, than]
-    - [sebelum, stelah, atas, bawah, ke, dari, naik, turun, dalam, luar, di atas, di bawah,  lagi, lebih lanjut, daripada]
+    - [sebelum, stelah, atas, bawah, ke, dari, naik, turun, dalam, luar, di atas, di bawah,  lagi, lebih, lanjut, daripada]
 adjectives: 
     # [own, same] 
     - [sendiri, sama] 

--- a/yaml/stopwords_id.yml
+++ b/yaml/stopwords_id.yml
@@ -1,40 +1,55 @@
 # Created by Hiroko Kinoshita for the marimo stopwords: https://github.com/koheiw/marimo
 
-stopwords:
-    pronoun: 
-        basic: 
-            - [saya, aku, gue, diri, sendiri, kita, kami, anda, kamu, engkau, saudara, milikmu, dirimu, dia, ia, beliau, kepunyaannya, punyanya, itu, ini, mereka, bahwa, yang, sehingga, agar, kalau, supaya, maka, bahwasanya, agar supaya, di waktu mana]
-        possesive: 
-            - [milikku, milik saya, milik*]
-        interogative: 
-            # added "whose"
-            - [apa, mana, siapa, siapapun, kapan, ketika, jika, waktu, sewaktu, bila, apabila, dimana, ke, dari, padahal, mengapa, kenapa, kok, bagaimana, berapa]
-        contraction: 
-            - [inilah, itulah, sudah, punya, akan, ingin]
-    verb: 
-        basic: 
-            - [adalah, ialah, dulu, menjadi, ada, berada, telah, mendapat, melakukan, berbuat, membuat, buat, dilakukan, perbuatan, merupakan]
-        modal: 
-        contraction: 
-            - [tidak, bukan, jangan, tak, tidak akan, tidak bisa, tdk dapat, tdk bisa, tidak harus, ayo, siapa yang, disini adalah, adah, adalah, kapan, dimana, kenapa, bagaimana, hal]
-        reporting: 
-            # added
-            - [mengatakan, kata, berkata, mengucapkan, berucap, ujar, berpendapat, bilang, membilangkan, mengomong, memprikan, mengira, tersebut, yang disebut di atas, menceritakan, menyuruh, bercerita, mengetahui, mengenali, mengenal, menunjukkan, menandakan, jelaskan, mengadukan, deberitahu, melapor*, mengabarkan, memberitahu*, mewartakan, lapor, merencana, unjuk bertahu, laporan, warta, renana, repot, dilaporkan]
-    article: 
-        - [sebuah, seorang, sebatang, itu, sang]
-    conjunction:
-        - [dan, serta, dengan, tambah, tetapi, melainkan, rupanya, jika, apakah, bila, atau, karena, sebab, begitu, amat, jadi, demikian, sementara, sedangkan, sambil, meski*, sembari, walaupun, seraya, saat, maupun, namun]
-    adverb: 
-        # added "many"
-        - [sebagai, seperti, ajak, sampai, sehingga, hingga, sekali, pernah, begini, sana, sekian, semua, segenap, segela, sekalian, sesuatu, kedua*, tiap*, masing*, beberapa, sedikit, tidak banyak, tdk banyak, banyak, lebih, lagi, tambah, menang, paling, sangat, amat, terlebih, lain, satu lagi, salah, salah satu, stengah, hebat, sedemikian, hanya, saja, baru, cuma, semata*, melulu, kemudian,  terus, teralu, pula, kelewat, benar*, banget, benar, seluruh]
-    preposition: 
-        - [di, oleh, dengan, menurut, untuk, bagi, selama, dengan, bersama, pada, tentang, megenai, soal, terhadap, di sekitar, melawan,  antara, di antara, menjadi, ke dalam, melalui, melewat*, sebelum, daripada, atas, bawah, naik, menaikkan, menurunkan, menjatuhkan, meletakkan, hanyut, lebih,  kembali, sekali lagi, pula, selanjutnya]
-    adjectives: 
-        - [sendiri, kepunyaan sendiri, sama, serupa, sama saja] 
-    time:
-        # added
-        - [menit, detik, jam, pukul, saat, waktu, bulan, tahun, abad, am, pm, hari]
-        - [januari, februari, maret, april, mei, juni, juli, agustus, september, oktober, november, desember, jan, feb, mar, apr, jun, jul, aug, sep, sept, okt, nov, des]
-    number:
-        - [satu, dua, tiga, empat, lima, enam, tujuj, delapan, sembilan, sepuluh]
+pronoun: 
+    basic: 
+        # [i, me, myself, we, ours, ourselves, you, yours, yourself, yourselves, he, him, himself, she, hers, herself, it, itself, they, them, theirs, themselves, this, that, these, those]
+        - [saya, aku, gue, diri, sendiri, kita, kami, anda, kamu, engkau, saudara, milikmu, dirimu, dia, ia, beliau, kepunyaannya, punyanya, itu, ini, mereka, bahwa, yang, sehingga, agar, kalau, supaya, maka, bahwasanya, agar supaya, di waktu mana]
+    possesive: 
+        # [my, our, your, his, her, its, their][my, our, your, his, her, its, their]
+        - [milikku, milik saya, milik*]
+    interogative: 
+        # [what, which, who, whom, whose, when, where, why, how]
+        - [apa, mana, siapa, siapapun, kapan, ketika, jika, waktu, sewaktu, bila, apabila, dimana, ke, dari, padahal, mengapa, kenapa, kok, bagaimana, berapa]
+    contraction: 
+        # [i'm, you're, he's, she's, it's, we're, they're, i've, you've, we've, they've, i'd, you'd, he'd, she'd, we'd, they'd, i'll, you'll, he'll, she'll, we'll, they'll]
+        - [inilah, itulah, sudah, punya, akan, ingin]
+verb: 
+    basic: 
+        # [am, is, are, was, were, be, been, being, have, has, had, having, do, does, did, doing]
+        - [adalah, ialah, dulu, menjadi, ada, berada, telah, mendapat, melakukan, berbuat, membuat, buat, dilakukan, perbuatan, merupakan]
+    modal: 
+        # [would, should, could, ought, will]
+        - []
+    contraction: 
+        # [isn't, aren't, wasn't, weren't, hasn't, haven't, hadn't, doesn't, don't, didn't, won't, wouldn't, shan't, shouldn't, can't, cannot, couldn't, mustn't, let's, that's, who's, what's, here's, there's, when's, where's, why's, how's]
+        - [tidak, bukan, jangan, tak, tidak akan, tidak bisa, tdk dapat, tdk bisa, tidak harus, ayo, siapa yang, disini adalah, adah, adalah, kapan, dimana, kenapa, bagaimana, hal]
+    reporting: 
+        # [say, says, said, tell, tells, told, report, reports, reported]
+        - [mengatakan, kata, berkata, mengucapkan, berucap, ujar, berpendapat, bilang, membilangkan, mengomong, memprikan, mengira, tersebut, yang disebut di atas, menceritakan, menyuruh, bercerita, mengetahui, mengenali, mengenal, menunjukkan, menandakan, jelaskan, mengadukan, deberitahu, melapor*, mengabarkan, memberitahu*, mewartakan, lapor, merencana, unjuk bertahu, laporan, warta, renana, repot, dilaporkan]
+article: 
+    # [a, an, the]
+    - [sebuah, seorang, sebatang, itu, sang]
+conjunction:
+    # [and, but, if, or, because, so, while, nor]
+    - [dan, serta, dengan, tambah, tetapi, melainkan, rupanya, jika, apakah, bila, atau, karena, sebab, begitu, amat, jadi, demikian, sementara, sedangkan, sambil, meski*, sembari, walaupun, seraya, saat, maupun, namun]
+adverb: 
+    # [as, until, once, here, there, all, any, both, each, few, many, more, most, other, some, such, "no", not, only, then, too, very, little, less]
+    - [sebagai, seperti, ajak, sampai, sehingga, hingga, sekali, pernah, begini, sana, sekian, semua, segenap, segela, sekalian, sesuatu, kedua*, tiap*, masing*, beberapa, sedikit, tidak banyak, tdk banyak, banyak, lebih, lagi, tambah, menang, paling, sangat, amat, terlebih, lain, satu lagi, salah, salah satu, stengah, hebat, sedemikian, hanya, saja, baru, cuma, semata*, melulu, kemudian,  terus, teralu, pula, kelewat, benar*, banget, benar, seluruh]
+preposition: 
+    # [of, at, by, for, with, about, against, between, into, through, during, before, after, above, below, to, from, up, down, in, out, "on", "off", over, under, again, further, than]
+    - [di, oleh, dengan, menurut, untuk, bagi, selama, dengan, bersama, pada, tentang, megenai, soal, terhadap, di sekitar, melawan,  antara, di antara, menjadi, ke dalam, melalui, melewat*, sebelum, daripada, atas, bawah, naik, menaikkan, menurunkan, menjatuhkan, meletakkan, hanyut, lebih,  kembali, sekali lagi, pula, selanjutnya]
+adjectives: 
+    # [own, same] 
+    - [sendiri, kepunyaan sendiri, sama, serupa, sama saja] 
+time:
+    # [minute, hour, month, year, century, am, pm]
+    - [menit, detik, jam, pukul, saat, waktu, bulan, tahun, abad, am, pm, hari]
+    # [january, february, march, april, may, june, july, august, september, october, november, december, jan, feb, mar, apr, may, jun, jul, aug, sep, sept, oct, nov, dec]
+    - [januari, februari, maret, april, mei, juni, juli, agustus, september, oktober, november, desember, jan, feb, mar, apr, jun, jul, aug, sep, sept, okt, nov, des]
+    # [sunday, monday, tuesday, wednesday, thursday, friday, saturday]
+number:
+    # [one, two, three, four, five, six, seven, eight, nine, ten]
+    - [satu, dua, tiga, empat, lima, enam, tujuj, delapan, sembilan, sepuluh]
+    # [first, second, third, fourth, fifth, seventh, eighth, nineth, tenth]
+    - []
 

--- a/yaml/stopwords_id.yml
+++ b/yaml/stopwords_id.yml
@@ -14,7 +14,7 @@ pronoun:
         - [apa, mana, siapa*, kapan, ketika, mengapa, kenapa, bagaimana]
     contraction: 
         # [i'm, you're, he's, she's, it's, we're, they're, i've, you've, we've, they've, i'd, you'd, he'd, she'd, we'd, they'd, i'll, you'll, he'll, she'll, we'll, they'll]
-        - [sudah]
+    
 verb: 
     basic: 
         # [am, is, are, was, were, be, been, being, have, has, had, having, do, does, did, doing]

--- a/yaml/stopwords_id.yml
+++ b/yaml/stopwords_id.yml
@@ -8,7 +8,7 @@ pronoun:
         - [itu, ini, mereka, bahwa*, yang]
     possesive: 
         # [my, our, your, his, her, its, their][my, our, your, his, her, its, their]
-        - [milikku, milik saya, milik*]
+        - [milik*]
     interogative: 
         # [what, which, who, whom, whose, when, where, why, how]
         - [apa, mana, siapa*, kapan, ketika, mengapa, kenapa, bagaimana]
@@ -43,9 +43,9 @@ adverb:
     - [lain, beberapa, hanya, "tidak", "bukan", saja, cuma, sangat, sedikit, banyak]
 preposition: 
     # [of, at, by, for, with, about, against, between, into, through, during]
-    - [di, oleh, dengan, menurut, untuk, bagi, dengan, pada, tentang, terhadap, antara, di antara, ke dalam, melalui, melewat*]
+    - [di, oleh, dengan, menurut, untuk, bagi, dengan, pada, tentang, terhadap, antara, melalui, melewat*]
     # [before, after, above, below, to, from, up, down, in, out, "on", "off", over, under, again, further, than]
-    - [sebelum, stelah, atas, bawah, ke, dari, naik, turun, dalam, luar, di atas, di bawah,  lagi, lebih, lanjut, daripada]
+    - [sebelum, stelah, atas, bawah, ke, dari, naik, turun, dalam, luar, lagi, lebih, lanjut, daripada]
 adjectives: 
     # [own, same] 
     - [sendiri, sama] 

--- a/yaml/stopwords_id.yml
+++ b/yaml/stopwords_id.yml
@@ -3,55 +3,55 @@
 pronoun: 
     basic: 
         # [i, me, myself, we, ours, ourselves, you, yours, yourself, yourselves, he, him, himself, she, hers, herself]
-        - [saya, aku, gue, sendiri, kita, kami, anda, kamu, engkau, saudara, milikmu, dirimu, dia, ia, beliau, kepunyaannya, punya*]
+        - [saya, aku, gue, sendiri, kita, kami, anda, kamu, engkau, kau, lo, kalian, milikmu, dirimu, dia, ia, beliau, kepunyaannya, punya*]
         # [it, itself, they, them, theirs, themselves, this, that, these, those]
         - [itu, ini, mereka, bahwa*, yang]
     possesive: 
         # [my, our, your, his, her, its, their][my, our, your, his, her, its, their]
-        - [milik*]
+        - [milik*, punya*]
     interogative: 
         # [what, which, who, whom, whose, when, where, why, how]
-        - [apa, mana, siapa*, kapan, ketika, mengapa, kenapa, bagaimana]
+        - [apa*, yang, mana*, siapa*, kapan, ketika, mengapa, kenapa, bagaimana]
     contraction: 
         # [i'm, you're, he's, she's, it's, we're, they're, i've, you've, we've, they've, i'd, you'd, he'd, she'd, we'd, they'd, i'll, you'll, he'll, she'll, we'll, they'll]
     
 verb: 
     basic: 
         # [am, is, are, was, were, be, been, being, have, has, had, having, do, does, did, doing]
-        - [adalah, dulu, menjadi,berada, telah, makhluk, melakukan, berbuat, dilakukan, perbuatan]
+        - [adalah, dulu, menjadi, jadi, berada, telah, melakukan, berbuat, dilakukan, perbuatan, memperbuat, diperbuat]
     modal: 
         # [would, should, could, ought, will]
-        - [akan, harus, bisa, seharusnya]
+        - [akan, harus, bisa, seharusnya, harusnya, sebaiknya]
     contraction: 
         # [isn't, aren't, wasn't, weren't, hasn't, haven't, hadn't, doesn't, don't, didn't, won't, wouldn't, shan't, shouldn't, can't, cannot, couldn't, mustn't, let's, that's, who's, what's, here's, there's, when's, where's, why's, how's]
     
     reporting: 
         # [say, says, said, tell, tells, told]
-        - [mengatakan, kata*, berkata, mengucapkan, berucap, ujar, berpendapat, bilang, membilangkan, mengomong, memprikan,mengira, menceritakan, menyuruh, bercerita, mengetahui, mengenal*, menunjukkan]
+        - [mengatakan, kata*, berkata, dikatakan, mengucapkan, berucap, ujar, berujar, berpendapat, bilang, membilangkan, mengomong, ngomong, mengira, menceritakan, menyuruh, bercerita, mengetahui, mengenal*, menunjukkan, memperlihatkan, memberitahu, memberitahukan, menerangkan, jelaskan, menjelaskan, mengumumkan]
         # [report, reports, reported]
-        - [jelaskan, deberitahu, melapor*, mengabarkan, memberitahu*, mewartakan, lapor*, merencana, repot, dilaporkan]
+        - [jelaskan, diberitahu, melapor*, melaporkan, mengabarkan, memberitahu*, mewartakan, lapor*, dilaporkan, dikabarkan, mengumumkan]
 article: 
     # [a, an, the]
     - [sebuah, sebatang, sang]
 conjunction:
     # [and, but, if, or, because, so, while, nor]
-    - [dan, serta, dengan, tambah, tetapi, melainkan, jika, atau, karena, sebab, begitu, amat, jadi, demikian, sementara, sedangkan, sambil, meski*, walaupun, maupun, namun]
+    - [dan, serta, dengan, tambah, tetapi, tapi, melainkan, jika, atau, karena, dikarenakan, sebab, disebabkan, jadi, sementara, sedangkan, sambil, meski*, walaupun, maupun, namun]
 adverb: 
     # [as, until, once, here, there, all, any, both, each, few, many, more, most]
-    - [sebagai, seperti, ajak, sampai, sehingga, hingga, sekali, sini, sana, semua, segenap, segela, sekalian, sesuatu, kedua*, tiap*, masing*, banyak, lebih, paling]
-    # [other, some, such, "no", not, only, then, too, very, little, less]
-    - [lain, beberapa, hanya, "tidak", "bukan", saja, cuma, sangat, sedikit, banyak]
+    - [sebagai, seperti, sampai, sehingga, hingga, sekali, sini, sana, semua, segenap, segala, sekalian, sesuatu, kedua*, setiap, tiap*, masing*, sedikit, dikit, beberapa, banyak, kebanyakan, lebih, paling]
+    # [other, some, such, "no", not, only, then, too, very, little, less, more]
+    - [lain, lainnya, beberapa, seperti, semacam, "tidak", "bukan", hanya, saja, aja, cuma, lalu, kemudian, maka, terlalu, sangat, sedikit, banyak, lebih]
 preposition: 
     # [of, at, by, for, with, about, against, between, into, through, during]
-    - [di, oleh, dengan, menurut, untuk, bagi, dengan, pada, tentang, terhadap, antara, melalui, melewat*]
+    - [di, pada, oleh, dengan, menurut, untuk, bagi, dengan, bersama, tentang, mengenai, terhadap, antara, dalam, melalui, melewat*, selama, saat]
     # [before, after, above, below, to, from, up, down, in, out, "on", "off", over, under, again, further, than]
-    - [sebelum, stelah, atas, bawah, ke, dari, naik, turun, dalam, luar, lagi, lebih, lanjut, daripada]
+    - [sebelum, sebelumnya, setelah, setelahnya, sesudah, sesudahnya, atas, bawah, ke, dari, naik, turun, dalam, luar, lagi, lebih, lanjut, daripada]
 adjectives: 
     # [own, same] 
-    - [sendiri, sama] 
+    - [diri, sendiri, sama] 
 time:
-    # [minute, hour, month, year, century, am, pm]
-    - [menit, jam, pukul, saat, waktu, bulan, tahun, abad, am, pm]
+    # [second, minute, hour, month, year, century, am, pm]
+    - [detik, menit, jam, pukul, saat, waktu, bulan, tahun, abad, am, pm]
     # [january, february, march, april, may, june, july, august, september, october, november, december, jan, feb, mar, apr, may, jun, jul, aug, sep, sept, oct, nov, dec]
     - [januari, februari, maret, april, mei, juni, juli, agustus, september, oktober, november, desember, jan, feb, mar, apr, jun, jul, aug, sep, sept, okt, nov, des]
     # [sunday, monday, tuesday, wednesday, thursday, friday, saturday]
@@ -59,8 +59,8 @@ time:
 number:
     cardinal:
         # [one, two, three, four, five, six, seven, eight, nine, ten]
-        - [satu, dua, tiga, empat, lima, enam, tujuj, delapan, sembilan, sepuluh]
+        - [satu, dua, tiga, empat, lima, enam, tujuh, delapan, sembilan, sepuluh]
     ordinal: 
         # [first, second, third, fourth, fifth, seventh, eighth, nineth, tenth]
-        - [pertama, kedua, ketiga, keempat, kelima, ketujuh, kedelapan, kesembilan, kesepuluh]
+        - [pertama, kedua, ketiga, keempat, kelima, keenam, ketujuh, kedelapan, kesembilan, kesepuluh]
 

--- a/yaml/stopwords_id.yml
+++ b/yaml/stopwords_id.yml
@@ -55,7 +55,7 @@ time:
     # [january, february, march, april, may, june, july, august, september, october, november, december, jan, feb, mar, apr, may, jun, jul, aug, sep, sept, oct, nov, dec]
     - [januari, februari, maret, april, mei, juni, juli, agustus, september, oktober, november, desember, jan, feb, mar, apr, jun, jul, aug, sep, sept, okt, nov, des]
     # [sunday, monday, tuesday, wednesday, thursday, friday, saturday]
-    - [Minggu, Senin, Selasa, Rabu, Kamis, Jumat, Sabtu]
+    - [minggu, senin, selasa, rabu, kamis, jumat, sabtu]
 number:
     cardinal:
         # [one, two, three, four, five, six, seven, eight, nine, ten]

--- a/yaml/stopwords_id.yml
+++ b/yaml/stopwords_id.yml
@@ -35,17 +35,17 @@ article:
     - [sebuah, sebatang, sang]
 conjunction:
     # [and, but, if, or, because, so, while, nor]
-    - [dan, serta, dengan, tambah, tetapi, tapi, melainkan, jika, atau, karena, dikarenakan, sebab, disebabkan, jadi, sementara, sedangkan, sambil, meski*, walaupun, maupun, namun]
+    - [dan, serta, dengan, tambah, tetapi, tapi, agar, melainkan, jika, atau, karena, dikarenakan, sebab, disebabkan, jadi, sementara, sedangkan, sambil, meski*, walaupun, maupun, namun]
 adverb: 
     # [as, until, once, here, there, all, any, both, each, few, many, more, most]
-    - [sebagai, seperti, sampai, sehingga, hingga, sekali, sini, sana, semua, segenap, segala, sekalian, sesuatu, kedua*, setiap, tiap*, masing*, sedikit, dikit, beberapa, banyak, kebanyakan, lebih, paling]
+    - [sebagai, seperti, sampai, sehingga, hingga, sekali, sini, sana, semua, seluruh, segenap, segala, sekalian, sesuatu, kedua*, setiap, tiap*, masing*, sedikit, dikit, beberapa, banyak, kebanyakan, lebih, paling]
     # [other, some, such, "no", not, only, then, too, very, little, less, more]
     - [lain, lainnya, beberapa, seperti, semacam, "tidak", "bukan", hanya, saja, aja, cuma, lalu, kemudian, maka, terlalu, sangat, sedikit, banyak, lebih]
 preposition: 
     # [of, at, by, for, with, about, against, between, into, through, during]
     - [di, pada, oleh, dengan, menurut, untuk, bagi, dengan, bersama, tentang, mengenai, terhadap, antara, dalam, melalui, melewat*, selama, saat]
     # [before, after, above, below, to, from, up, down, in, out, "on", "off", over, under, again, further, than]
-    - [sebelum, sebelumnya, setelah, setelahnya, sesudah, sesudahnya, atas, bawah, ke, dari, naik, turun, dalam, luar, lagi, lebih, lanjut, daripada]
+    - [sebelum, sebelumnya, setelah, setelahnya, sesudah, sesudahnya, atas, bawah, ke, kepada, dari, naik, turun, dalam, luar, lagi, kembali, lebih, lanjut, daripada]
 adjectives: 
     # [own, same] 
     - [diri, sendiri, sama] 


### PR DESCRIPTION
@hirokokinoshita  I restarted working on Indonesian stop words based on your PR #7. 

I tested the stop words by applying them to a large corpus of Media Indonesia articles.

```
> names(topfeatures(dfm(toks), 100))
  [1] ""             "juga"         "baca"         "indonesia"    "tersebut"     "dapat"       
  [7] "ada"          "secara"       "masyarakat"   "hari"         "orang"        "anak"        
 [13] "besar"        "kepada"       "pemerintah"   "baru"         "para"         "memiliki"    
 [19] "sudah"        "jakarta"      "negara"       "agar"         "program"      "baik"        
 [25] "setelah"      "berbagai"     "masih"        "memberikan"   "dunia"        "penting"     
 [31] "kota"         "hal"          "merupakan"    "terus"        "daerah"       "salah"       
 [37] "tetap"        "nasional"     "bersama"      "selain"       "langkah"      "rumah"       
 [43] "utama"        "kesehatan"    "seluruh"      "tinggi"       "tengah"       "presiden"    
 [49] "kerja"        "kembali"      "tim"          "membuat"      "wilayah"      "setiap"      
 [55] "selama"       "termasuk"     "ekonomi"      "mulai"        "proses"       "langsung"    
 [61] "terjadi"      "warga"        "sosial"       "lalu"         "menegaskan"   "tanpa"       
 [67] "sekitar"      "hukum"        "bagian"       "air"          "meningkatkan" "hasil"       
 [73] "membantu"     "belum"        "pendidikan"   "masa"         "kasus"        "hidup"       
 [79] "sejak"        "memastikan"   "terkait"      "tapi"         "menjaga"      "cara"        
 [85] "kondisi"      "depan"        "jawa"         "sebelumnya"   "kepala"       "kabupaten"   
 [91] "ingin"        "sistem"       "kegiatan"     "lingkungan"   "tak"          "mendukung"   
 [97] "pihak"        "berikut"      "kini"         "korban"      
```
I can see prepositions and be-verbs in the list (using Google Translate). Do you want to add them to the list?
 